### PR TITLE
fix : 아이콘 토큰 및 공통 컴포넌트 사용 적용 및 수정

### DIFF
--- a/src/components/layout/AppBackButton.tsx
+++ b/src/components/layout/AppBackButton.tsx
@@ -7,18 +7,14 @@ type Props =
 export function AppBackButton({ href, onClick }: Props) {
   if (href) {
     return (
-      <Link
-        href={href}
-        className="icon [--icon-mask:var(--ico-arrow)]"
-        aria-label="뒤로가기"
-      />
+      <Link href={href} className="icon icon-back" aria-label="뒤로가기" />
     );
   }
   return (
     <button
       type="button"
       onClick={onClick}
-      className="icon [--icon-mask:var(--ico-arrow)]"
+      className="icon icon-back"
       aria-label="뒤로가기"
     />
   );

--- a/src/components/layout/AppLogoLink.tsx
+++ b/src/components/layout/AppLogoLink.tsx
@@ -4,7 +4,7 @@ export function AppLogoLink() {
   return (
     <Link
       href="/"
-      className="icon size-10 [--icon-mask:var(--ico-logo)]"
+      className="icon icon-logo size-10"
       aria-label="NULLNULL 홈"
     />
   );

--- a/src/features/auth/components/Loginform.tsx
+++ b/src/features/auth/components/Loginform.tsx
@@ -4,12 +4,12 @@ import { Button } from "@/components/ui/button";
 
 const loginFeatures = [
   {
-    icon: "var(--ico-main-link)",
+    icon: "icon-main-link",
     title: "빠른 링크 공유",
     description: "참여자들에게 링크만 전달하세요",
   },
   {
-    icon: "var(--ico-main-timer)",
+    icon: "icon-main-timer",
     title: "자동 시간 추천",
     description: "가장 많이 겹치는 시간을 찾아드려요",
   },
@@ -21,10 +21,7 @@ export function LoginForm() {
       leftSlot={<AppLogoLink />}
       bottomSlot={
         <Button className="h-14 w-full gap-2 rounded-2xl border-0 bg-[#FEE500] text-base font-semibold text-black/90 shadow-[0_4px_7px_rgba(254,229,0,0.4)] hover:bg-[#FEE500]/90">
-          <span
-            className="icon !size-[18px] [--icon-mask:var(--ico-kakao)]"
-            aria-hidden="true"
-          />
+          <span className="icon icon-kakao !size-[18px]" aria-hidden="true" />
           카카오로 3초 만에 시작하기
         </Button>
       }
@@ -52,8 +49,7 @@ export function LoginForm() {
             >
               <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-gray-50 text-gray-500">
                 <span
-                  className="icon size-5"
-                  style={{ "--icon-mask": feature.icon } as React.CSSProperties}
+                  className={`icon ${feature.icon} size-5`}
                   aria-hidden="true"
                 />
               </div>

--- a/src/features/room/RoomDetail.tsx
+++ b/src/features/room/RoomDetail.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { AppShell } from "@/components/layout/AppShell";
+import { AppLogoLink, AppShell } from "@/components/layout";
 import { Button } from "@/components/ui/button";
 import { RoomDetailView } from "./components/detail/RoomDetailView";
 import { JoinNameStep } from "./components/detail/JoinNameStep";
@@ -49,9 +49,7 @@ export function RoomDetail({ slug }: Props) {
   if (isEnded) {
     return (
       <AppShell
-        leftSlot={
-          <Link href="/" className="icon icon-logo" aria-label="nullnull 홈" />
-        }
+        leftSlot={<AppLogoLink />}
         bottomSlot={
           <Button size="cta" asChild>
             <Link href="/room">새 모임 만들기</Link>
@@ -74,9 +72,7 @@ export function RoomDetail({ slug }: Props) {
 
   return (
     <AppShell
-      leftSlot={
-        <Link href="/" className="icon icon-logo" aria-label="nullnull 홈" />
-      }
+      leftSlot={<AppLogoLink />}
       bottomSlot={
         <Button size="cta" onClick={() => setView("join-name")}>
           참여하기

--- a/src/features/room/components/create/CreateRoomComplete.tsx
+++ b/src/features/room/components/create/CreateRoomComplete.tsx
@@ -124,7 +124,7 @@ export function CreateRoomComplete({
             <div className="h-2 w-full bg-gray-100 rounded-full overflow-hidden">
               <div className="h-full bg-primary w-[75%] rounded-full" />
             </div>
-            <span className="text-[10px] text-gray-500 text-right">
+            <span className="text-xs text-gray-500 text-right">
               75% 제출 완료
             </span>
           </div>

--- a/src/features/room/components/create/CreateRoomStep1.tsx
+++ b/src/features/room/components/create/CreateRoomStep1.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Input } from "@/components/ui/input";
 
 export function CreateRoomStep1() {
   return (
@@ -14,10 +15,9 @@ export function CreateRoomStep1() {
         <label className="text-sm font-medium text-gray-700">
           닉네임 <span className="text-red-500">*</span>
         </label>
-        <input
+        <Input
           type="text"
           placeholder="발넓은모임장"
-          className="w-full h-12 px-4 rounded-xl border border-gray-200 focus:outline-none focus:border-[#6B4EFF] focus:ring-1 focus:ring-[#6B4EFF] bg-white"
           defaultValue="발넓은모임장"
         />
       </div>

--- a/src/features/room/components/create/CreateRoomStep2.tsx
+++ b/src/features/room/components/create/CreateRoomStep2.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Input } from "@/components/ui/input";
 
 export function CreateRoomStep2() {
   return (
@@ -16,11 +17,7 @@ export function CreateRoomStep2() {
         <label className="text-sm font-medium text-gray-700">
           모임 이름 <span className="text-red-500">*</span>
         </label>
-        <input
-          type="text"
-          placeholder="2자 ~ 40자"
-          className="w-full h-12 px-4 rounded-xl border border-gray-200 focus:outline-none focus:border-[#6B4EFF] bg-white"
-        />
+        <Input type="text" placeholder="2자 ~ 40자" />
       </div>
 
       <div className="flex flex-col gap-2">

--- a/src/features/room/components/create/CreateRoomStep3.tsx
+++ b/src/features/room/components/create/CreateRoomStep3.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
+import { Input } from "@/components/ui/input";
 
 const TIME_OPTIONS = Array.from({ length: 24 }).map((_, i) => {
   const isPM = i >= 12;
@@ -34,15 +35,15 @@ export function CreateRoomStep3() {
           희망 날짜 범위 <span className="text-red-500">*</span>
         </label>
         <div className="flex items-center gap-2">
-          <input
+          <Input
             type="date"
-            className="flex-1 h-12 px-3 rounded-xl border border-gray-200 text-sm bg-white"
+            className="flex-1 px-3 text-sm"
             defaultValue="2026-05-01"
           />
           <span className="text-gray-400">~</span>
-          <input
+          <Input
             type="date"
-            className="flex-1 h-12 px-3 rounded-xl border border-gray-200 text-sm bg-white"
+            className="flex-1 px-3 text-sm"
             defaultValue="2026-05-30"
           />
         </div>
@@ -86,7 +87,7 @@ export function CreateRoomStep3() {
             onClick={() => setPreferredDay("weekday")}
             className={`flex-1 font-medium text-sm transition-colors relative ${
               preferredDay === "weekday"
-                ? "bg-[#6B4EFF] text-white z-10"
+                ? "bg-primary text-primary-foreground z-10"
                 : "text-gray-700 hover:bg-gray-50"
             }`}
           >
@@ -96,7 +97,7 @@ export function CreateRoomStep3() {
             onClick={() => setPreferredDay("weekend")}
             className={`flex-1 font-medium text-sm transition-colors relative ${
               preferredDay === "weekend"
-                ? "bg-[#6B4EFF] text-white z-10"
+                ? "bg-primary text-primary-foreground z-10"
                 : "text-gray-700 hover:bg-gray-50"
             }`}
           >
@@ -106,7 +107,7 @@ export function CreateRoomStep3() {
             onClick={() => setPreferredDay("custom")}
             className={`flex-1 font-medium text-sm transition-colors relative ${
               preferredDay === "custom"
-                ? "bg-[#6B4EFF] text-white z-10"
+                ? "bg-primary text-primary-foreground z-10"
                 : "text-gray-700 hover:bg-gray-50"
             }`}
           >
@@ -121,7 +122,7 @@ export function CreateRoomStep3() {
                 onClick={() => toggleDay(day)}
                 className={`flex-1 h-10 rounded-xl font-medium text-sm transition-colors border ${
                   customDays.includes(day)
-                    ? "bg-[#F5F3FF] text-[#6B4EFF] border-[#6B4EFF]"
+                    ? "bg-primary-subtle text-primary border-primary"
                     : "bg-white text-gray-700 border-gray-200 hover:bg-gray-50"
                 }`}
               >
@@ -138,9 +139,9 @@ export function CreateRoomStep3() {
           투표 마감일 <span className="text-red-500">*</span>
         </label>
         <div className="flex items-center gap-2">
-          <input
+          <Input
             type="date"
-            className="flex-1 h-12 px-3 rounded-xl border border-gray-200 text-sm bg-white"
+            className="flex-1 px-3 text-sm"
             defaultValue="2026-05-07"
           />
           <select
@@ -171,7 +172,7 @@ export function CreateRoomStep3() {
             onClick={() => setRecommendPlace(false)}
             className={`flex-1 rounded-xl font-medium text-sm transition-colors border ${
               !recommendPlace
-                ? "bg-[#F5F3FF] text-[#6B4EFF] border-[#6B4EFF]"
+                ? "bg-primary-subtle text-primary border-primary"
                 : "bg-white text-gray-700 border-gray-200 hover:bg-gray-50"
             }`}
           >
@@ -181,7 +182,7 @@ export function CreateRoomStep3() {
             onClick={() => setRecommendPlace(true)}
             className={`flex-1 rounded-xl font-medium text-sm transition-colors border ${
               recommendPlace
-                ? "bg-[#F5F3FF] text-[#6B4EFF] border-[#6B4EFF]"
+                ? "bg-primary-subtle text-primary border-primary"
                 : "bg-white text-gray-700 border-gray-200 hover:bg-gray-50"
             }`}
           >

--- a/src/features/room/components/detail/JoinNameStep.tsx
+++ b/src/features/room/components/detail/JoinNameStep.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { AppShell } from "@/components/layout/AppShell";
+import { AppBackButton, AppContent, AppShell } from "@/components/layout";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { PrivacyConsentSheet } from "./PrivacyConsentSheet";
 
 const RANDOM_NICKNAMES = [
@@ -45,13 +46,7 @@ export function JoinNameStep({ onBack, onComplete }: Props) {
   return (
     <AppShell
       title={<span className="text-base">모임 참여하기</span>}
-      leftSlot={
-        <button
-          onClick={onBack}
-          className="icon icon-back"
-          aria-label="뒤로가기"
-        />
-      }
+      leftSlot={<AppBackButton onClick={onBack} />}
       bottomSlot={
         <Button size="cta" onClick={handleNext}>
           다음
@@ -66,7 +61,7 @@ export function JoinNameStep({ onBack, onComplete }: Props) {
         )
       }
     >
-      <div className="px-5 py-8 flex flex-col gap-6">
+      <AppContent className="flex flex-col gap-6">
         <div>
           <h2 className="text-2xl font-bold text-gray-900 mb-2">
             어떤 이름으로 참여할까요?
@@ -80,7 +75,7 @@ export function JoinNameStep({ onBack, onComplete }: Props) {
           <label className="text-sm font-medium text-gray-700">
             이름 <span className="text-red-500">*</span>
           </label>
-          <input
+          <Input
             type="text"
             value={name}
             onChange={(e) => {
@@ -89,11 +84,10 @@ export function JoinNameStep({ onBack, onComplete }: Props) {
             }}
             placeholder="이름을 입력해 주세요"
             aria-invalid={!!error}
-            className="w-full h-12 px-4 rounded-xl border border-gray-200 focus:outline-none focus:border-[#6B4EFF] focus:ring-1 focus:ring-[#6B4EFF] bg-white aria-[invalid=true]:border-red-400"
           />
           {error && <p className="text-xs text-red-500">{error}</p>}
         </div>
-      </div>
+      </AppContent>
     </AppShell>
   );
 }

--- a/src/features/room/components/detail/RoomEndedView.tsx
+++ b/src/features/room/components/detail/RoomEndedView.tsx
@@ -50,7 +50,7 @@ export function RoomEndedView() {
             className="bg-white rounded-2xl shadow-sm p-4 flex items-center justify-between hover:bg-gray-50 transition-colors"
           >
             <div className="flex flex-col gap-1">
-              <span className="text-xs font-medium text-[#6B4EFF] bg-[#F0EDFF] px-2 py-0.5 rounded-full w-fit">
+              <span className="text-xs font-medium text-primary bg-primary-subtle px-2 py-0.5 rounded-full w-fit">
                 {room.category}
               </span>
               <p className="text-sm font-bold text-gray-900">{room.title}</p>

--- a/src/features/room/components/location/LocationPage.tsx
+++ b/src/features/room/components/location/LocationPage.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { AppShell } from "@/components/layout/AppShell";
+import { AppBackButton, AppContent, AppShell } from "@/components/layout";
 import { Button } from "@/components/ui/button";
 import { MapView } from "@/components/MapView";
 import { LocationSearchSheet } from "./LocationSearchSheet";
@@ -26,13 +26,7 @@ export function LocationPage({ slug }: Props) {
   return (
     <AppShell
       title={<span className="text-base">모임 참여하기</span>}
-      leftSlot={
-        <button
-          onClick={() => router.back()}
-          className="icon icon-back"
-          aria-label="뒤로가기"
-        />
-      }
+      leftSlot={<AppBackButton onClick={() => router.back()} />}
       bottomSlot={
         <div className="flex flex-col gap-1">
           <Button size="cta" disabled={!location} onClick={handleComplete}>
@@ -58,7 +52,7 @@ export function LocationPage({ slug }: Props) {
         )
       }
     >
-      <div className="px-5 py-8 flex flex-col gap-6">
+      <AppContent className="flex flex-col gap-6">
         {!location ? (
           /* 출발지 미선택 상태 */
           <>
@@ -129,7 +123,7 @@ export function LocationPage({ slug }: Props) {
             </div>
           </>
         )}
-      </div>
+      </AppContent>
     </AppShell>
   );
 }

--- a/src/features/room/components/location/LocationSearchSheet.tsx
+++ b/src/features/room/components/location/LocationSearchSheet.tsx
@@ -98,7 +98,7 @@ export function LocationSearchSheet({ onClose, onSelect }: Props) {
                   onClick={() => onSelect(loc)}
                 >
                   <span
-                    className="icon icon-deadline text-[#6B4EFF] shrink-0 mt-0.5"
+                    className="icon icon-deadline text-primary shrink-0 mt-0.5"
                     aria-hidden="true"
                   />
                   <div className="flex flex-col gap-0.5 min-w-0">

--- a/src/styles/icon.css
+++ b/src/styles/icon.css
@@ -147,3 +147,128 @@
     mask-size: var(--icon-mask-size, contain);
     -webkit-mask-size: var(--icon-mask-size, contain);
 }
+
+.icon-logo {
+    --icon-mask: var(--ico-logo);
+}
+
+.icon-main-link {
+    --icon-mask: var(--ico-main-link);
+}
+
+.icon-main-timer {
+    --icon-mask: var(--ico-main-timer);
+}
+
+.icon-kakao {
+    --icon-mask: var(--ico-kakao);
+}
+
+.icon-noti {
+    --icon-mask: var(--ico-noti);
+}
+
+.icon-arrow,
+.icon-back {
+    --icon-mask: var(--ico-arrow);
+}
+
+.icon-more {
+    --icon-mask: var(--ico-more);
+}
+
+.icon-alarm {
+    --icon-mask: var(--ico-alarm);
+}
+
+.icon-setting {
+    --icon-mask: var(--ico-setting);
+}
+
+.icon-add {
+    --icon-mask: var(--ico-add);
+}
+
+.icon-close {
+    --icon-mask: var(--ico-close);
+}
+
+.icon-link {
+    --icon-mask: var(--ico-link);
+}
+
+.icon-timelapse {
+    --icon-mask: var(--ico-timelapse);
+}
+
+.icon-photo-add {
+    --icon-mask: var(--ico-photo_add);
+}
+
+.icon-calendar {
+    --icon-mask: var(--ico-calendar);
+}
+
+.icon-person-add {
+    --icon-mask: var(--ico-person_add);
+}
+
+.icon-group-add {
+    --icon-mask: var(--ico-group_add);
+}
+
+.icon-deadline {
+    --icon-mask: var(--ico-deadline);
+}
+
+.icon-deily {
+    --icon-mask: var(--ico-deily);
+}
+
+.icon-time {
+    --icon-mask: var(--ico-time);
+}
+
+.icon-host {
+    --icon-mask: var(--ico-host);
+}
+
+.icon-person {
+    --icon-mask: var(--ico-person);
+}
+
+.icon-food {
+    --icon-mask: var(--ico-food);
+}
+
+.icon-anniv {
+    --icon-mask: var(--ico-anniv);
+}
+
+.icon-coffee {
+    --icon-mask: var(--ico-coffee);
+}
+
+.icon-bar {
+    --icon-mask: var(--ico-bar);
+}
+
+.icon-game {
+    --icon-mask: var(--ico-game);
+}
+
+.icon-study {
+    --icon-mask: var(--ico-study);
+}
+
+.icon-exercise {
+    --icon-mask: var(--ico-exercise);
+}
+
+.icon-meeting {
+    --icon-mask: var(--ico-meeting);
+}
+
+.icon-star {
+    --icon-mask: var(--ico-star);
+}


### PR DESCRIPTION
## 변경 내용


- 아이콘 사용 방식을 `icon icon-*` 클래스 조합으로 통일했습니다.
  - `icon-*` 클래스는 아이콘 mask만 담당하도록 정리
  - `[--icon-mask:...]` 직접 사용 제거

- 공통 레이아웃 컴포넌트 사용을 정리했습니다.
  - 로고는 `AppLogoLink`로 통일
  - 뒤로가기 버튼은 `AppBackButton`으로 통일
  - 일부 페이지의 콘텐츠 래퍼를 `AppContent`로 통일

- 방 생성/참여 화면의 기본 UI 컴포넌트 사용을 정리했습니다.
  - 직접 작성한 input을 공통 `Input` 컴포넌트로 교체
  - 하드코딩된 primary 계열 색상을 토큰 클래스(`text-primary`, `bg-primary-subtle`, `border-primary` 등)로 변경

## 관련 이슈

- Closes #

## 참고 사항

-

## 확인 사항

- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 없는 변경은 포함하지 않았습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.
