### PR TITLE
Feat/dialog

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -284,6 +284,8 @@
   }
 
   .Wrap .wrap-container {
+    position: relative;
+    isolation: isolate;
     display: flex;
     flex-direction: column;
     width: 100%;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,6 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import { QueryProvider } from "@/components/providers/QueryProvider";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "NULLNULL",
@@ -24,10 +13,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html
-      lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
-    >
+    <html lang="ko" className={`h-full antialiased`}>
       <body className="min-h-full flex flex-col">
         <QueryProvider>{children}</QueryProvider>
       </body>

--- a/src/components/dialog/AppDialog.tsx
+++ b/src/components/dialog/AppDialog.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+
+import { DialogActions } from "./DialogActions";
+import type { AppDialogProps, DialogAction, DialogSize } from "./types";
+import { useDialogOpen } from "./useDialogOpen";
+
+const DEFAULT_ALERT_ACTIONS: DialogAction[] = [{ label: "확인" }];
+
+const DEFAULT_CONFIRM_ACTIONS: DialogAction[] = [
+  { label: "취소", variant: "secondary" },
+  { label: "확인" },
+];
+
+const alertContentClassName: Record<DialogSize, string> = {
+  default: "w-[calc(100%-40px)] max-w-[320px] rounded-2xl p-5",
+  compact: "w-[calc(100%-40px)] max-w-[320px] rounded-3xl p-4",
+};
+
+const alertTitleClassName: Record<DialogSize, string> = {
+  default: "text-base font-bold",
+  compact: "text-xl font-semibold",
+};
+
+const alertDescriptionClassName: Record<DialogSize, string> = {
+  default: "text-sm leading-[18px]",
+  compact: "text-base font-medium leading-6",
+};
+
+const alertHeaderClassName: Record<DialogSize, string> = {
+  default: "gap-1",
+  compact: "gap-4",
+};
+
+const alertFooterClassName: Record<DialogSize, string> = {
+  default: "gap-2 pt-3",
+  compact: "gap-3 pt-4",
+};
+
+export function AppDialog({
+  type,
+  engine = "sheet",
+  dialogSize = "default",
+  title,
+  description,
+  content,
+  actions,
+  open,
+  defaultOpen,
+  onOpenChange,
+  className,
+  children,
+}: AppDialogProps) {
+  const dialog = useDialogOpen({ open, defaultOpen, onOpenChange });
+  const resolvedActions =
+    actions ??
+    (type === "alert" ? DEFAULT_ALERT_ACTIONS : DEFAULT_CONFIRM_ACTIONS);
+
+  if (type === "bottom") {
+    return (
+      <BottomDialogContent
+        engine={engine}
+        title={title}
+        description={description}
+        content={content}
+        actions={resolvedActions}
+        className={className}
+        dialogSize={dialogSize}
+        trigger={children}
+        open={dialog.open}
+        onOpenChange={dialog.onOpenChange}
+      />
+    );
+  }
+
+  return (
+    <AlertDialogContentByType
+      type={type}
+      title={title}
+      description={description}
+      content={content}
+      actions={resolvedActions}
+      className={className}
+      dialogSize={dialogSize}
+      trigger={children}
+      open={dialog.open}
+      onOpenChange={dialog.onOpenChange}
+    />
+  );
+}
+
+function AlertDialogContentByType({
+  type,
+  title,
+  description,
+  content,
+  actions,
+  className,
+  dialogSize,
+  trigger,
+  open,
+  onOpenChange,
+}: {
+  type: AppDialogProps["type"];
+  title?: string;
+  description?: string;
+  content?: ReactNode;
+  actions: DialogAction[];
+  className?: string;
+  dialogSize: DialogSize;
+  trigger?: ReactNode;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      {trigger && <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>}
+      <AlertDialogContent
+        className={cn(alertContentClassName[dialogSize], className)}
+      >
+        <AlertDialogHeader
+          className={cn(
+            "place-items-start text-left",
+            alertHeaderClassName[dialogSize],
+          )}
+        >
+          <AlertDialogTitle
+            className={cn("text-text-primary", alertTitleClassName[dialogSize])}
+          >
+            {title ?? (type === "alert" ? "알림" : "확인")}
+          </AlertDialogTitle>
+          <AlertDialogDescription
+            className={cn(
+              "text-text-secondary",
+              alertDescriptionClassName[dialogSize],
+            )}
+          >
+            {description ?? "내용을 확인해주세요."}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {content}
+
+        <AlertDialogFooter
+          className={cn(
+            "grid border-0 bg-transparent p-0",
+            alertFooterClassName[dialogSize],
+            actions.length === 2 && "grid-cols-2",
+            actions.length === 3 && "grid-cols-3",
+          )}
+        >
+          <DialogActions
+            actions={actions}
+            size={dialogSize}
+            onClose={() => onOpenChange(false)}
+          />
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function BottomDialogContent({
+  engine,
+  title,
+  description,
+  content,
+  actions,
+  className,
+  dialogSize,
+  trigger,
+  open,
+  onOpenChange,
+}: {
+  engine: NonNullable<AppDialogProps["engine"]>;
+  title?: string;
+  description?: string;
+  content?: ReactNode;
+  actions: DialogAction[];
+  className?: string;
+  dialogSize: DialogSize;
+  trigger?: ReactNode;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  if (engine === "drawer") {
+    return (
+      <Drawer open={open} onOpenChange={onOpenChange} direction="bottom">
+        {trigger && <DrawerTrigger asChild>{trigger}</DrawerTrigger>}
+        <DrawerContent className={cn("rounded-t-2xl", className)}>
+          <DrawerHeader className="p-5 text-left">
+            {title && <DrawerTitle>{title}</DrawerTitle>}
+            {description && (
+              <DrawerDescription>{description}</DrawerDescription>
+            )}
+          </DrawerHeader>
+          {content}
+          {actions.length > 0 && (
+            <DrawerFooter className="p-5 pt-0">
+              <DialogActions
+                actions={actions}
+                size={dialogSize}
+                onClose={() => onOpenChange(false)}
+              />
+            </DrawerFooter>
+          )}
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      {trigger && <SheetTrigger asChild>{trigger}</SheetTrigger>}
+      <SheetContent
+        side="bottom"
+        showCloseButton={false}
+        className={cn("rounded-t-2xl p-0", className)}
+      >
+        <SheetHeader className="p-5 text-left">
+          {title && <SheetTitle>{title}</SheetTitle>}
+          {description && <SheetDescription>{description}</SheetDescription>}
+        </SheetHeader>
+        {content}
+        {actions.length > 0 && (
+          <SheetFooter className="p-5 pt-0">
+            <DialogActions
+              actions={actions}
+              size={dialogSize}
+              onClose={() => onOpenChange(false)}
+            />
+          </SheetFooter>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/dialog/DialogActions.tsx
+++ b/src/components/dialog/DialogActions.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import type { DialogAction, DialogSize } from "./types";
+
+type DialogActionsProps = {
+  actions: DialogAction[];
+  size?: DialogSize;
+  onClose?: () => void;
+};
+
+const actionVariantClassName: Record<
+  NonNullable<DialogAction["variant"]>,
+  string
+> = {
+  primary: "",
+  secondary: "border-0 bg-gray-50 text-text-primary hover:bg-gray-100",
+  danger: "bg-red-500 text-white hover:bg-red-500/90",
+  ghost: "bg-transparent text-text-primary hover:bg-gray-50",
+};
+
+const actionSizeClassName: Record<DialogSize, string> = {
+  default: "!h-14 rounded-xl text-sm",
+  compact: "!h-14 rounded-xl text-base",
+};
+
+export function DialogActions({
+  actions,
+  size = "default",
+  onClose,
+}: DialogActionsProps) {
+  return (
+    <>
+      {actions.map((action, index) => (
+        <Button
+          key={`${action.label}-${index}`}
+          type="button"
+          className={cn(
+            "w-full font-semibold",
+            actionSizeClassName[size],
+            actionVariantClassName[action.variant ?? "primary"],
+          )}
+          disabled={action.disabled}
+          onClick={async () => {
+            await action.onClick?.();
+
+            if (action.closeOnClick !== false) {
+              onClose?.();
+            }
+          }}
+        >
+          {action.label}
+        </Button>
+      ))}
+    </>
+  );
+}

--- a/src/components/dialog/README.md
+++ b/src/components/dialog/README.md
@@ -1,0 +1,182 @@
+# Dialog 사용 규칙
+
+프로젝트에서 alert, confirm, bottom sheet 계열 팝업은 `AppDialog`를 기준으로 사용합니다.
+`src/components/ui/alert-dialog.tsx`, `sheet.tsx`, `drawer.tsx`는 shadcn/Radix 래퍼이므로 페이지에서 직접 조합하기보다 `AppDialog`를 우선 사용합니다.
+
+## 기본 원칙
+
+- 페이지에서는 `AppDialog`를 사용합니다.
+- 트리거 버튼은 `AppDialog`의 `children`으로 전달합니다.
+- `title`, `description`, `actions`로 dialog 내용을 구성합니다.
+- dim과 dialog는 공통으로 `.wrap-container` 기준에 렌더링됩니다.
+  - `AppDialog`는 내부적으로 `AlertDialogContent`, `SheetContent`, `DrawerContent`를 사용합니다.
+  - 이 ui 래퍼들이 `getDialogContainer()`를 통해 `.wrap-container` 기준으로 portal을 렌더링합니다.
+  (AppDialog는 내부적으로 AlertDialogContent, SheetContent, DrawerContent를 사용하며, 이 ui 래퍼들이 getDialogContainer()를 통해 .wrap-container 기준으로 portal을 렌더링합니다.)
+- `alert-dialog`, `sheet`, `drawer`의 `Overlay` 이름은 dim 역할이므로 그대로 사용합니다.
+- 페이지 전용 문구, API 호출, 라우팅 처리는 페이지 또는 feature 영역에서 관리합니다.
+
+## 사용 예시
+
+```tsx
+<AppDialog
+  type="confirm"
+  title="모집을 마감할까요?"
+  description="모집을 마감하면 더 이상 답변을 받을 수 없어요"
+  actions={[
+    { label: "취소", variant: "secondary" },
+    { label: "마감하기", onClick: handleCloseRecruit },
+  ]}
+>
+  <Button size="cta">모집 마감하기</Button>
+</AppDialog>
+```
+
+`children`은 내부에서 Radix의 `Trigger asChild`로 연결됩니다. 접근성을 위해 별도의 외부 `onClick`으로 dialog를 여는 방식보다 이 방식을 우선 사용합니다.
+
+## type
+
+현재 구현된 타입만 사용합니다.
+
+```ts
+type DialogType = "alert" | "confirm" | "bottom";
+```
+
+| type | 용도 |
+| --- | --- |
+| `alert` | 확인 버튼 중심의 단순 안내 |
+| `confirm` | 취소/확인처럼 사용자 결정을 받는 팝업 |
+| `bottom` | 하단에서 올라오는 sheet/drawer 형태 |
+
+`dialog`, `full` 같은 타입은 실제 레이아웃이 구현된 뒤 추가합니다. 타입만 먼저 열어두지 않습니다.
+
+## dialogSize
+
+화면마다 dialog 크기가 다를 수 있으므로 `dialogSize`로 구분합니다.
+
+```tsx
+<AppDialog dialogSize="compact" />
+```
+
+| size | 용도 |
+| --- | --- |
+| `default` | 모집 마감 등 일반 confirm |
+| `compact` | 설정 로그아웃, 회원탈퇴 dialog |
+
+`compact`는 Production Figma 기준으로 다음 규칙을 따릅니다.
+
+- alert padding: `p-4` = 16px
+- 버튼 높이: `h-14` = 56px
+- 버튼 간격: `gap-3` = 12px
+- title: `text-xl font-semibold` = 20px semibold
+- description: `text-base font-medium` = 16px medium
+
+`dialogSize`는 alert/confirm뿐 아니라 `type="bottom"`의 action 버튼에도 전달됩니다.
+따라서 bottom 타입에서도 같은 버튼 크기 규칙을 사용할 수 있습니다.
+
+## actions
+
+버튼은 `actions` 배열로 정의합니다.
+
+```tsx
+actions={[
+  { label: "취소", variant: "secondary" },
+  { label: "로그아웃", onClick: logout },
+]}
+```
+
+### action 속성
+
+| 속성 | 설명 |
+| --- | --- |
+| `label` | 버튼 텍스트 |
+| `variant` | `primary`, `secondary`, `danger`, `ghost` |
+| `onClick` | 버튼 클릭 시 실행할 함수 |
+| `disabled` | 버튼 비활성화 |
+| `closeOnClick` | `false`면 클릭 후 dialog를 닫지 않음 |
+
+`onClick`은 비동기 함수도 허용합니다.
+
+```tsx
+actions={[
+  {
+    label: "마감하기",
+    onClick: async () => {
+      await closeRecruitment();
+    },
+  },
+]}
+```
+
+기본 동작은 `onClick` 완료 후 dialog를 닫는 것입니다. API 실패 시 닫히지 않게 하려면 `onClick` 내부에서 에러를 처리하거나 `closeOnClick: false`를 사용합니다.
+
+액션 버튼은 배열 순서대로 렌더링됩니다. 취소 버튼이 필요한 경우 첫 번째 action으로 둡니다.
+취소 버튼도 별도 처리 없이 기본적으로 클릭 후 dialog가 닫힙니다.
+
+## open과 defaultOpen
+
+`open`은 controlled prop입니다.
+
+```tsx
+const [open, setOpen] = useState(false);
+
+<AppDialog open={open} onOpenChange={setOpen} />
+```
+
+처음 렌더링 시 열어두고 내부에서 닫히게 하려면 `defaultOpen`을 사용합니다.
+
+```tsx
+<AppDialog defaultOpen />
+```
+
+`open`만 단독으로 넘기는 방식은 사용하지 않습니다.
+
+```tsx
+// 사용하지 않음
+<AppDialog open />
+```
+
+## bottom 타입
+
+`type="bottom"`은 하단 팝업입니다.
+
+```tsx
+<AppDialog
+  type="bottom"
+  engine="sheet"
+  title="약관에 동의해주세요"
+  actions={[{ label: "확인" }]}
+>
+  <Button>열기</Button>
+</AppDialog>
+```
+
+`engine`은 기본값이 `sheet`입니다.
+
+| engine | 기준 |
+| --- | --- |
+| `sheet` | 일반적인 하단 sheet |
+| `drawer` | drag 동작 등 drawer 성격이 필요할 때 |
+
+디자인상 둘 다 bottom sheet처럼 보여도 기능 차이가 있으므로 `engine`으로 구분합니다.
+
+`engine`은 `type="bottom"`일 때만 의미가 있습니다.
+`alert`, `confirm`에서는 `engine`을 지정하지 않습니다.
+
+## 하지 말아야 할 것
+
+- 페이지에서 shadcn `AlertDialogContent`, `AlertDialogFooter`를 직접 조합하지 않습니다.
+- dialog를 열기 위해 별도 id manager를 만들지 않습니다.
+- `open`만 단독으로 넘겨 테스트하지 않습니다. 테스트용 초기 열림은 `defaultOpen`을 사용합니다.
+- 페이지 전용 props constants를 shared/common 영역에 두지 않습니다.
+- 아직 구현되지 않은 dialog 타입을 미리 열어두지 않습니다.
+
+## 파일 책임
+
+| 파일 | 책임 |
+| --- | --- |
+| `AppDialog.tsx` | dialog/sheet/drawer 선택과 공통 레이아웃 |
+| `DialogActions.tsx` | actions 배열을 버튼 UI로 렌더링 |
+| `types.ts` | dialog public 타입 |
+| `useDialogOpen.ts` | controlled/uncontrolled open 상태 처리 |
+| `src/components/ui/*` | shadcn/Radix 기반 원자 컴포넌트 |
+| `src/lib/getDialogContainer.ts` | `.wrap-container` 기준 portal container 조회 |

--- a/src/components/dialog/index.ts
+++ b/src/components/dialog/index.ts
@@ -1,0 +1,10 @@
+export { AppDialog } from "./AppDialog";
+export { DialogActions } from "./DialogActions";
+export type {
+  AppDialogProps,
+  BottomDialogEngine,
+  DialogAction,
+  DialogActionVariant,
+  DialogBase,
+  DialogType,
+} from "./types";

--- a/src/components/dialog/types.ts
+++ b/src/components/dialog/types.ts
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+
+export type DialogType = "alert" | "confirm" | "bottom" /*| "dialog" | "full"*/;
+
+export type BottomDialogEngine = "drawer" | "sheet";
+
+export type DialogSize = "default" | "compact";
+
+export type DialogActionVariant = "primary" | "secondary" | "danger" | "ghost";
+
+export type DialogAction = {
+  label: string;
+  variant?: DialogActionVariant;
+  onClick?: () => void | Promise<void>;
+  disabled?: boolean;
+  closeOnClick?: boolean;
+};
+
+export type DialogBase = {
+  type: DialogType;
+  title?: string;
+  description?: string;
+  content?: ReactNode;
+  actions?: DialogAction[];
+};
+
+export type AppDialogProps = DialogBase & {
+  engine?: BottomDialogEngine;
+  dialogSize?: DialogSize;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  className?: string;
+  children?: ReactNode;
+};

--- a/src/components/dialog/useDialogOpen.ts
+++ b/src/components/dialog/useDialogOpen.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState, useSyncExternalStore } from "react";
+
+type UseDialogOpenOptions = {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+};
+
+const subscribe = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+export function useDialogOpen({
+  open,
+  defaultOpen = false,
+  onOpenChange,
+}: UseDialogOpenOptions) {
+  const isClient = useSyncExternalStore(
+    subscribe,
+    getClientSnapshot,
+    getServerSnapshot,
+  );
+  const isControlled = open !== undefined;
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const currentOpen = isClient && (isControlled ? open : internalOpen);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!isControlled) {
+      setInternalOpen(nextOpen);
+    }
+
+    onOpenChange?.(nextOpen);
+  };
+
+  return {
+    open: currentOpen,
+    onOpenChange: handleOpenChange,
+    isControlled,
+  };
+}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -5,6 +5,7 @@ import { AlertDialog as AlertDialogPrimitive } from "radix-ui";
 
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { getDialogContainer } from "@/lib/getDialogContainer";
 
 function AlertDialog({
   ...props
@@ -61,11 +62,7 @@ function AlertDialogContent({
   size?: "default" | "sm";
   scope?: "viewport" | "container";
 }) {
-  const defaultPortalContainer =
-    typeof document === "undefined"
-      ? null
-      : document.querySelector<HTMLElement>(".wrap-container");
-  const container = portalContainer ?? defaultPortalContainer ?? undefined;
+  const container = portalContainer ?? getDialogContainer();
 
   return (
     <AlertDialogPortal container={container}>
@@ -108,7 +105,7 @@ function AlertDialogFooter({
     <div
       data-slot="alert-dialog-footer"
       className={cn(
-        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        "flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
         className,
       )}
       {...props}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { Drawer as DrawerPrimitive } from "vaul";
 
 import { cn } from "@/lib/utils";
+import { getDialogContainer } from "@/lib/getDialogContainer";
 
 function Drawer({
   ...props
@@ -31,13 +32,17 @@ function DrawerClose({
 
 function DrawerOverlay({
   className,
+  scope = "container",
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay> & {
+  scope?: "viewport" | "container";
+}) {
   return (
     <DrawerPrimitive.Overlay
       data-slot="drawer-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        scope === "container" ? "absolute" : "fixed",
+        "inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className,
       )}
       {...props}
@@ -48,15 +53,23 @@ function DrawerOverlay({
 function DrawerContent({
   className,
   children,
+  portalContainer,
+  scope = "container",
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+}: React.ComponentProps<typeof DrawerPrimitive.Content> & {
+  portalContainer?: HTMLElement | null;
+  scope?: "viewport" | "container";
+}) {
+  const container = portalContainer ?? getDialogContainer();
+
   return (
-    <DrawerPortal data-slot="drawer-portal">
-      <DrawerOverlay />
+    <DrawerPortal data-slot="drawer-portal" container={container}>
+      <DrawerOverlay scope={scope} />
       <DrawerPrimitive.Content
         data-slot="drawer-content"
         className={cn(
-          "group/drawer-content fixed z-50 flex h-auto flex-col bg-popover text-sm text-popover-foreground data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-xl data-[vaul-drawer-direction=bottom]:border-t data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:rounded-r-xl data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:rounded-l-xl data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-xl data-[vaul-drawer-direction=top]:border-b data-[vaul-drawer-direction=left]:sm:max-w-sm data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          "group/drawer-content z-50 flex h-auto flex-col bg-popover text-sm text-popover-foreground data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-xl data-[vaul-drawer-direction=bottom]:border-t data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:rounded-r-xl data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:rounded-l-xl data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-xl data-[vaul-drawer-direction=top]:border-b data-[vaul-drawer-direction=left]:sm:max-w-sm data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          scope === "container" ? "absolute" : "fixed",
           className,
         )}
         {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -5,6 +5,7 @@ import { Dialog as SheetPrimitive } from "radix-ui";
 
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { getDialogContainer } from "@/lib/getDialogContainer";
 import { XIcon } from "lucide-react";
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
@@ -31,13 +32,17 @@ function SheetPortal({
 
 function SheetOverlay({
   className,
+  scope = "container",
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+}: React.ComponentProps<typeof SheetPrimitive.Overlay> & {
+  scope?: "viewport" | "container";
+}) {
   return (
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        scope === "container" ? "absolute" : "fixed",
+        "inset-0 z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className,
       )}
       {...props}
@@ -48,21 +53,28 @@ function SheetOverlay({
 function SheetContent({
   className,
   children,
+  portalContainer,
   side = "right",
   showCloseButton = true,
+  scope = "container",
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  portalContainer?: HTMLElement | null;
   side?: "top" | "right" | "bottom" | "left";
   showCloseButton?: boolean;
+  scope?: "viewport" | "container";
 }) {
+  const container = portalContainer ?? getDialogContainer();
+
   return (
-    <SheetPortal>
-      <SheetOverlay />
+    <SheetPortal container={container}>
+      <SheetOverlay scope={scope} />
       <SheetPrimitive.Content
         data-slot="sheet-content"
         data-side={side}
         className={cn(
-          "fixed z-50 flex flex-col gap-4 bg-popover bg-clip-padding text-sm text-popover-foreground shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10",
+          scope === "container" ? "absolute" : "fixed",
+          "z-50 flex flex-col gap-4 bg-popover bg-clip-padding text-sm text-popover-foreground shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10",
           className,
         )}
         {...props}

--- a/src/features/home/HomePage.tsx
+++ b/src/features/home/HomePage.tsx
@@ -83,9 +83,16 @@ export function HomePage() {
     <AppShell
       leftSlot={<AppLogoLink />}
       rightSlot={
-        <Button className="h-10 rounded-xl px-4" asChild>
-          <Link href="/login">로그인</Link>
-        </Button>
+        <>
+          <Button className="h-10 rounded-xl px-4" asChild>
+            <Link href="/login">로그인</Link>
+          </Button>
+          {/* TODO: 설정 dialog 확인용 임시 버튼입니다. 확인 후 삭제해주세요. */}
+          <Button className="h-10 rounded-xl px-4" variant="outline" asChild>
+            <Link href="/setting">설정 확인</Link>
+          </Button>
+          {/* END */}
+        </>
       }
       bottomSlot={
         <Button size="cta" asChild>

--- a/src/features/home/SettingPage.tsx
+++ b/src/features/home/SettingPage.tsx
@@ -1,23 +1,14 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { AppShell, AppContent } from "@/components/layout";
-import { useAuthStore } from "@/store/useAuthStore";
-import { useAuth } from "@/features/auth/hooks/useAuth";
-import { Switch } from "@/components/ui/switch";
-import { ChevronLeft, ChevronRight } from "lucide-react";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
 import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+import { AppContent, AppShell } from "@/components/layout";
+import { AppDialog } from "@/components/dialog";
+import { Switch } from "@/components/ui/switch";
+import { useAuth } from "@/features/auth/hooks/useAuth";
+import { useAuthStore } from "@/store/useAuthStore";
 
 export function SettingPage() {
   const router = useRouter();
@@ -98,71 +89,45 @@ export function SettingPage() {
             </div>
           </section>
 
-          {/* 하단 여백 채우기 */}
-          <div className="flex-1"></div>
+          <div className="flex-1" />
 
-          <section className="px-5 pb-10 pt-4 flex items-center justify-center gap-4 text-sm font-medium">
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <button className="text-gray-400 hover:text-gray-600">
-                  로그아웃
-                </button>
-              </AlertDialogTrigger>
-              <AlertDialogContent className="w-[320px] rounded-2xl">
-                <AlertDialogHeader>
-                  <AlertDialogTitle className="text-center text-lg font-bold">
-                    로그아웃을 진행하시겠어요?
-                  </AlertDialogTitle>
-                  <AlertDialogDescription className="text-center text-sm text-gray-500">
-                    로그아웃 하면 알림을 받을 수 없어요
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter className="flex-row items-center gap-3 sm:justify-center mt-4">
-                  <AlertDialogCancel className="mt-0 flex-1 rounded-xl h-12 text-sm font-semibold bg-gray-50 border-none hover:bg-gray-100">
-                    취소
-                  </AlertDialogCancel>
-                  <AlertDialogAction
-                    onClick={() => logout()}
-                    disabled={isLoggingOut}
-                    className="flex-1 rounded-xl h-12 text-sm font-semibold bg-blue-500 text-white hover:bg-blue-600"
-                  >
-                    로그아웃
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
+          <section className="flex items-center justify-center gap-4 px-5 pb-10 pt-4 text-sm font-medium">
+            <AppDialog
+              type="confirm"
+              dialogSize="compact"
+              title="로그아웃을 진행하시겠어요?"
+              description="로그아웃하면 알림을 받을 수 없어요"
+              actions={[
+                { label: "취소", variant: "secondary" },
+                { label: "로그아웃", onClick: logout, disabled: isLoggingOut },
+              ]}
+            >
+              <button className="text-gray-400 hover:text-gray-600">
+                로그아웃
+              </button>
+            </AppDialog>
 
             <span className="text-gray-300">|</span>
 
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <button className="text-red-400 hover:text-red-500">
-                  회원탈퇴
-                </button>
-              </AlertDialogTrigger>
-              <AlertDialogContent className="w-[320px] rounded-2xl">
-                <AlertDialogHeader>
-                  <AlertDialogTitle className="text-center text-lg font-bold">
-                    탈퇴 시 모든 모임 기록이 사라져요
-                  </AlertDialogTitle>
-                  <AlertDialogDescription className="text-center text-sm text-gray-500">
-                    그래도 탈퇴 하시겠어요?
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter className="flex-row items-center gap-3 sm:justify-center mt-4">
-                  <AlertDialogCancel className="mt-0 flex-1 rounded-xl h-12 text-sm font-semibold bg-gray-50 border-none hover:bg-gray-100">
-                    취소
-                  </AlertDialogCancel>
-                  <AlertDialogAction
-                    onClick={() => withdraw()}
-                    disabled={isWithdrawing}
-                    className="flex-1 rounded-xl h-12 text-sm font-semibold bg-red-500 text-white hover:bg-red-600"
-                  >
-                    회원탈퇴
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
+            <AppDialog
+              type="confirm"
+              dialogSize="compact"
+              title="탈퇴 시 모든 모임 기록이 사라져요"
+              description="그래도 탈퇴하시겠어요?"
+              actions={[
+                { label: "취소", variant: "secondary" },
+                {
+                  label: "회원탈퇴",
+                  variant: "danger",
+                  onClick: withdraw,
+                  disabled: isWithdrawing,
+                },
+              ]}
+            >
+              <button className="text-red-400 hover:text-red-500">
+                회원탈퇴
+              </button>
+            </AppDialog>
           </section>
         </div>
       </AppContent>

--- a/src/features/room/RoomDetail.tsx
+++ b/src/features/room/RoomDetail.tsx
@@ -10,32 +10,22 @@ import {
   AppShareButton,
   AppShell,
 } from "@/components/layout";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
+import { AppDialog } from "@/components/dialog";
 import { Button } from "@/components/ui/button";
+import { useRoomJoinStore } from "@/store/useRoomJoinStore";
 
 import { JoinNameStep } from "./components/detail/JoinNameStep";
+import { PrivacyConsentSheet } from "./components/detail/PrivacyConsentSheet";
 import { RoomDashboardView } from "./components/detail/RoomDashboardView";
 import { RoomDetailView } from "./components/detail/RoomDetailView";
 import { RoomEndedView } from "./components/detail/RoomEndedView";
 import { RoomResultView } from "./components/detail/RoomResultView";
-import { PrivacyConsentSheet } from "./components/detail/PrivacyConsentSheet";
-import { useRoomJoinStore } from "@/store/useRoomJoinStore";
 import type { RoomApiResponse, RoomDetailData } from "./types/room";
 
 const MOCK_DETAIL_DATA: RoomDetailData = {
   viewer: {
     role: "MEMBER",
-    participantStatus: "JOINED",
+    participantStatus: "SUBMITTED",
     nickname: undefined,
     consentRequired: true,
   },
@@ -46,7 +36,7 @@ const MOCK_DETAIL_DATA: RoomDetailData = {
     status: "COLLECTING",
     hostNickname: "방만든모임장",
     badge: "진행중",
-    text: "안 되는 시간을 선택하고 모임을 확장해 보세요",
+    text: "안 되는 시간을 선택하고 모임을 확정해 보세요",
     dateStart: "2026-05-24",
     dateEnd: "2026-05-26",
     availableDays: [6, 7, 1],
@@ -87,6 +77,7 @@ export function RoomDetail({ slug }: Props) {
   const [data, setData] = useState<RoomDetailData>(MOCK_DETAIL_DATA);
   const [view, setView] = useState<View>("detail");
   const [privacyOpen, setPrivacyOpen] = useState(false);
+  const setJoin = useRoomJoinStore((state) => state.set);
 
   const room = useMemo(() => toRoomApiResponse(data, slug), [data, slug]);
   const { viewer, summary } = data;
@@ -134,8 +125,6 @@ export function RoomDetail({ slug }: Props) {
       setView("join-name");
     }
   };
-
-  const setJoin = useRoomJoinStore((s) => s.set);
 
   const handleJoinComplete = (name: string, uuid: string) => {
     setJoin(name, uuid);
@@ -254,38 +243,17 @@ function RoomDashboardBottomSlot({
   if (room.viewerRole === "HOST" && room.status === "COLLECTING") {
     return (
       <div className="flex flex-col gap-3">
-        <AlertDialog>
-          <AlertDialogTrigger asChild>
-            <Button size="cta">모집 마감하기</Button>
-          </AlertDialogTrigger>
-          <AlertDialogContent
-            className="w-[calc(100%-40px)] max-w-[320px] rounded-2xl p-5"
-            overlayClassName="bg-black/70"
-          >
-            <AlertDialogHeader className="place-items-start gap-1 text-left">
-              <AlertDialogTitle className="text-base font-bold text-text-primary">
-                모집을 마감할까요?
-              </AlertDialogTitle>
-              <AlertDialogDescription className="text-sm leading-[18px] text-text-secondary">
-                모집을 마감하면 더 이상 답변을 받을 수 없어요
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter className="-mx-0 -mb-0 grid grid-cols-2 gap-2 border-0 bg-transparent p-0 pt-2">
-              <AlertDialogCancel
-                variant="secondary"
-                className="!h-14 w-full rounded-xl text-sm font-semibold text-text-primary"
-              >
-                취소
-              </AlertDialogCancel>
-              <AlertDialogAction
-                className="!h-14 w-full rounded-xl text-sm font-semibold"
-                onClick={onCloseCollecting}
-              >
-                마감하기
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+        <AppDialog
+          type="confirm"
+          title="모집을 마감할까요?"
+          description="모집을 마감하면 더 이상 답변을 받을 수 없어요"
+          actions={[
+            { label: "취소", variant: "secondary" },
+            { label: "마감하기", onClick: onCloseCollecting },
+          ]}
+        >
+          <Button size="cta">모집 마감하기</Button>
+        </AppDialog>
         <Button
           size="cta"
           variant="ghost"

--- a/src/lib/getDialogContainer.ts
+++ b/src/lib/getDialogContainer.ts
@@ -1,0 +1,7 @@
+export function getDialogContainer() {
+  if (typeof document === "undefined") {
+    return undefined;
+  }
+
+  return document.querySelector<HTMLElement>(".wrap-container") ?? undefined;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,10 +5,23 @@ const protectedRoutes = ["/setting"];
 
 const authRoutes = ["/login"];
 
+// TODO: 설정 확인용 임시 우회입니다. 확인 후 이 블록만 삭제해주세요.
+const temporarySettingCheckRoutes = ["/setting"];
+// END
+
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   const authToken = request.cookies.get("access_token")?.value;
+  // TODO: 설정 확인용 임시 우회입니다. 확인 후 이 블록만 삭제해주세요.
+  const isTemporarySettingCheckRoute = temporarySettingCheckRoutes.some(
+    (route) => pathname.startsWith(route),
+  );
+
+  if (isTemporarySettingCheckRoute) {
+    return NextResponse.next();
+  }
+  //END
 
   const isProtectedRoute = protectedRoutes.some((route) =>
     pathname.startsWith(route),

--- a/src/styles/icon.css
+++ b/src/styles/icon.css
@@ -46,6 +46,9 @@
 
   /* 달력  */
   --ico-calendar: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cg clip-path='url(%23clip0_3420_2170)'%3E%3Cpath d='M19 4H18V3C18 2.45 17.55 2 17 2C16.45 2 16 2.45 16 3V4H8V3C8 2.45 7.55 2 7 2C6.45 2 6 2.45 6 3V4H5C3.89 4 3.01 4.9 3.01 6L3 20C3 21.1 3.89 22 5 22H19C20.1 22 21 21.1 21 20V6C21 4.9 20.1 4 19 4ZM19 19C19 19.55 18.55 20 18 20H6C5.45 20 5 19.55 5 19V9H19V19ZM7 11H9V13H7V11ZM11 11H13V13H11V11ZM15 11H17V13H15V11Z' fill='%23323232'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='clip0_3420_2170'%3E%3Crect width='24' height='24' fill='white'/%3E%3C/clipPath%3E%3C/defs%3E%3C/svg%3E%0A");
+  
+  /* 체크 표시 */
+  --ico-checked: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cg clip-path='url(%23clip0_4565_2750)'%3E%3Cpath d='M9 16.1998L5.5 12.6998C5.11 12.3098 4.49 12.3098 4.1 12.6998C3.71 13.0898 3.71 13.7098 4.1 14.0998L8.29 18.2898C8.68 18.6798 9.31 18.6798 9.7 18.2898L20.3 7.69982C20.69 7.30982 20.69 6.68982 20.3 6.29982C19.91 5.90982 19.29 5.90982 18.9 6.29982L9 16.1998Z' fill='black'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='clip0_4565_2750'%3E%3Crect width='24' height='24' fill='white'/%3E%3C/clipPath%3E%3C/defs%3E%3C/svg%3E%0A");
 
   /* 사람추가  */
   --ico-person_add: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cg clip-path='url(%23clip0_3441_4661)'%3E%3Cpath d='M15 12C17.21 12 19 10.21 19 8C19 5.79 17.21 4 15 4C12.79 4 11 5.79 11 8C11 10.21 12.79 12 15 12ZM6 10V8C6 7.45 5.55 7 5 7C4.45 7 4 7.45 4 8V10H2C1.45 10 1 10.45 1 11C1 11.55 1.45 12 2 12H4V14C4 14.55 4.45 15 5 15C5.55 15 6 14.55 6 14V12H8C8.55 12 9 11.55 9 11C9 10.45 8.55 10 8 10H6ZM15 14C12.33 14 7 15.34 7 18V19C7 19.55 7.45 20 8 20H22C22.55 20 23 19.55 23 19V18C23 15.34 17.67 14 15 14Z' fill='%23323232'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='clip0_3441_4661'%3E%3Crect width='24' height='24' fill='white'/%3E%3C/clipPath%3E%3C/defs%3E%3C/svg%3E%0A");
@@ -211,6 +214,10 @@
 
 .icon-calendar {
   --icon-mask: var(--ico-calendar);
+}
+
+.icon-checked {
+  --icon-mask: var(--ico-checked);
 }
 
 .icon-person-add {


### PR DESCRIPTION
## 변경 내용

- 결과조회/설정 화면에서 사용하는 dialog 공통 컴포넌트를 추가했습니다. 
- AppDialog를 통해 alert, confirm, bottom 타입의 팝업을 공통으로 사용할 수 있도록 정리했습니다. 
- dialog action 버튼을 actions 배열 기반으로 처리하도록 분리했습니다. 
- open, defaultOpen, onOpenChange 동작 규칙을 정리하고, 비동기 action 실행 후 닫힘 처리되도록 개선했습니다. 
- AlertDialog, Sheet, Drawer의 portal이 .wrap-container 기준으로 렌더링되도록 공통 container 조회 유틸을 추가했습니다. 
- 설정의 로그아웃/회원탈퇴 dialog와 방 상세의 모집 마감 dialog에 공통 AppDialog를 적용했습니다. 
- 팀원이 dialog 규칙을 참고할 수 있도록 src/components/dialog/README.md를 추가했습니다. 
- 설정 dialog 확인을 위해 임시 진입 버튼과 /setting 임시 우회를 추가했습니다. 
- checked 아이콘 토큰을 추가했습니다.
## 관련 이슈

- Closes #

## 참고 사항

- 설정 확인용 임시 버튼과 /setting 우회 코드는 추후 삭제가 필요합니다.
  - src/features/home/HomePage.tsx
  - src/proxy.ts
- 공통 컴포넌트인 AppDialog 내부에서는 shadcn/Radix 컴포넌트를 조합해서 쓴다.
- 각 페이지에서는 shadcn AlertDialogContent, SheetContent, DrawerContent를 직접 조합하지 말고 AppDialog를 사용한다.

## 확인 사항

- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 없는 변경은 포함하지 않았습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
