### PR TITLE
fix : HOST + COLLECTING + JOINED 상태 분기 링크 연결 수정

### DIFF
--- a/src/features/room/RoomDetail.tsx
+++ b/src/features/room/RoomDetail.tsx
@@ -13,6 +13,7 @@ import { LoadingView } from "@/components/visual/LoadingView";
 import { useRoomJoinStore } from "@/store/useRoomJoinStore";
 
 import { JoinNameStep } from "./components/detail/JoinNameStep";
+import { RoomCreatedView } from "./components/detail/RoomCreatedView";
 import { RoomDashboardView } from "./components/detail/RoomDashboardView";
 import { RoomDetailView } from "./components/detail/RoomDetailView";
 import { RoomEndedView } from "./components/detail/RoomEndedView";
@@ -109,8 +110,13 @@ export function RoomDetail({ slug }: Props) {
     viewer.role === "MEMBER" &&
     (viewer.participantStatus === "SUBMITTED" ||
       viewer.participantStatus === "DECLINED");
+  const isHostCreated =
+    viewer.role === "HOST" &&
+    room.status === "COLLECTING" &&
+    viewer.participantStatus === "JOINED";
   const isHostDashboard =
     viewer.role === "HOST" &&
+    !isHostCreated &&
     (room.status === "COLLECTING" ||
       room.status === "READY" ||
       room.status === "CONFIRMED" ||
@@ -232,6 +238,21 @@ export function RoomDetail({ slug }: Props) {
           onSelectTime={setSelectedTimeCandidateId}
           onSelectPlace={setSelectedPlaceCandidateId}
         />
+      </AppShell>
+    );
+  }
+
+  if (isHostCreated) {
+    return (
+      <AppShell
+        leftSlot={<AppLogoLink />}
+        bottomSlot={
+          <Button onClick={() => router.push(`/room/${slug}/schedule`)}>
+            내 일정 입력하기
+          </Button>
+        }
+      >
+        <RoomCreatedView room={roomForComponents} />
       </AppShell>
     );
   }

--- a/src/features/room/components/detail/RoomCreatedView.tsx
+++ b/src/features/room/components/detail/RoomCreatedView.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import positiveTitleBg from "@/assets/images/components/bg_positive_title.svg";
+import { Switch } from "@/components/ui/switch";
+import pulseStyles from "@/components/visual/LogoPulse.module.css";
+import { RoomInfoList } from "@/features/room/components/RoomInfoList";
+import { RoomTitle } from "@/features/room/components/RoomTitle";
+import type { RoomApiResponse } from "@/features/room/types/room";
+import {
+  formatDate,
+  formatDeadline,
+  formatDays,
+  formatTime,
+} from "@/shared/utils/format";
+
+type Props = {
+  room: RoomApiResponse;
+};
+
+export function RoomCreatedView({ room }: Props) {
+  return (
+    <div className="relative flex min-h-[inherit] flex-col overflow-hidden bg-gray-50 pb-8">
+      <div
+        className="pointer-events-none absolute left-1/2 top-[-40px] z-0 h-[300px] w-[120%] max-w-[500px] -translate-x-1/2 bg-contain bg-center bg-no-repeat opacity-70"
+        style={{ backgroundImage: `url(${positiveTitleBg.src})` }}
+      />
+
+      <section className="relative z-10 flex flex-col items-center px-5 pb-10 pt-[60px] text-center">
+        <div
+          className={`${pulseStyles.pulse} ${pulseStyles.blue} mb-6 flex size-20 items-center justify-center rounded-full bg-info/10`}
+        >
+          <div className="flex size-14 items-center justify-center rounded-full bg-gradient-to-br from-primary-default to-info text-white shadow-[0_8px_20px_-6px_rgba(91,110,225,0.4)]">
+            <span
+              className="icon icon-logo size-[38px]"
+              aria-label="NULLNULL"
+            />
+          </div>
+        </div>
+
+        <h1 className="text-2xl font-bold leading-8 text-text-primary">
+          모임을 만들었어요
+        </h1>
+        <p className="mt-3 text-sm font-medium leading-[18px] text-text-tertiary">
+          이제 안 되는 시간을 입력하고
+          <br />
+          참여자들에게 링크를 공유해 주세요
+        </p>
+      </section>
+
+      <div className="relative z-20 flex flex-col gap-4 px-5">
+        <div className="flex items-center justify-between rounded-3xl border border-border-subtle bg-white px-5 py-4">
+          <span className="text-sm font-bold leading-[18px] text-text-primary">
+            모임원이 들어오면 알림 받기
+          </span>
+          <Switch />
+        </div>
+
+        <div className="rounded-3xl border border-border-subtle bg-white">
+          <RoomTitle
+            title={room.name}
+            hostName={room.hostNickname}
+            category={room.category}
+            status={room.badge as Parameters<typeof RoomTitle>[0]["status"]}
+          />
+
+          <div className="h-px bg-border-subtle" />
+
+          <RoomInfoList
+            dateRange={{
+              start: formatDate(room.dateStart),
+              end: formatDate(room.dateEnd),
+            }}
+            timeRange={{
+              start: formatTime(room.timeStart),
+              end: formatTime(room.timeEnd),
+            }}
+            days={formatDays(room.availableDays)}
+            deadline={formatDeadline(room.deadlineAt)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 변경 내용

- 방 링크 접속 시 `HOST + COLLECTING + JOINED` 상태를 별도 분기 처리했습니다.
- 호스트가 아직 일정을 제출하지 않은 경우 `모임을 만들었어요` 화면을 보여주도록 추가했습니다.
- 해당 화면에서 `내 일정 입력하기` 흐름으로 이동할 수 있도록 연결했습니다.
- 피그마 기준에 맞춰 모임원 입장 알림 스위치 영역을 추가했습니다.

## 관련 이슈

- Closes #

## 참고 사항

- `JOINED`는 일정 제출 완료가 아니라 참여 등록만 된 상태로 보고 분기했습니다.
- `/room/{slug}`는 조회 API 데이터 기반이므로 생성 플로우의 `CreateRoomComplete` 대신 조회용 `RoomCreatedView`를 분리했습니다.
- 알림 스위치는 현재 UI만 반영되어 있으며 별도 API 연동은 포함하지 않았습니다.

## 확인 사항

- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 없는 변경은 포함하지 않았습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
